### PR TITLE
Use invariant culture for uppercase & lowercase

### DIFF
--- a/Assets/Xsolla/Core/WebRequests/WebRequestHelper.Analytics.cs
+++ b/Assets/Xsolla/Core/WebRequests/WebRequestHelper.Analytics.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -99,8 +100,8 @@ namespace Xsolla.Core
 				string referralPlugin = _referralAnalytics.Value.Key;
 				string referralVersion = _referralAnalytics.Value.Value;
 
-				result.Add(new WebRequestHeader() {Name = "X-REF", Value = referralPlugin.ToUpper()});
-				result.Add(new WebRequestHeader() {Name = "X-REF-V", Value = referralVersion.ToUpper()});
+				result.Add(new WebRequestHeader() {Name = "X-REF", Value = referralPlugin.ToUpper(CultureInfo.InvariantCulture)});
+				result.Add(new WebRequestHeader() {Name = "X-REF-V", Value = referralVersion.ToUpper(CultureInfo.InvariantCulture)});
 			}
 
 			return result;
@@ -145,11 +146,11 @@ namespace Xsolla.Core
 
 			if (toUpper)
 			{
-				engineVersion = engineVersion.ToUpper();
-				buildPlatform = buildPlatform.ToUpper();
+				engineVersion = engineVersion.ToUpper(CultureInfo.InvariantCulture);
+				buildPlatform = buildPlatform.ToUpper(CultureInfo.InvariantCulture);
 			}
 			else
-				buildPlatform = buildPlatform.ToLower();
+				buildPlatform = buildPlatform.ToLower(CultureInfo.InvariantCulture);
 		}
 	}
 }


### PR DESCRIPTION
## Objective
Fixing invalid characters in web request headers on Turkish OS display language.
```
InvalidOperationException: Header value contains invalid characters
UnityEngine.Networking.UnityWebRequest.SetRequestHeader (System.String name, System.String value) (at <63fb9d7bd92242a7b4218da88657af33>:0)
Xsolla.Core.WebRequestHelper.AttachHeadersToRequest (UnityEngine.Networking.UnityWebRequest webRequest, System.Collections.Generic.List`1[T] requestHeaders) (at Assets/Xsolla/Core/WebRequests/WebRequestHelper.cs:117)
Xsolla.Core.WebRequestHelper.AttachHeadersToPostRequest (UnityEngine.Networking.UnityWebRequest webRequest, System.Collections.Generic.List`1[T] requestHeaders, System.Boolean withContentType) (at Assets/Xsolla/Core/WebRequests/WebRequestHelper.POST.cs:285)
Xsolla.Core.WebRequestHelper.PreparePostWebRequest (System.String url, System.Object jsonObject, System.Collections.Generic.List`1[T] requestHeaders) (at Assets/Xsolla/Core/WebRequests/WebRequestHelper.POST.cs:247)
Xsolla.Core.WebRequestHelper+<PostRequestCor>d__62`1[T].MoveNext () (at Assets/Xsolla/Core/WebRequests/WebRequestHelper.POST.cs:194)
UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) (at <56073df97ede4f769c2cc45d546d986d>:0)
UnityEngine.MonoBehaviour:StartCoroutine(IEnumerator)
Xsolla.Core.WebRequestHelper:PostRequest(SdkType, String, SignInRequest, Action`1, Action`1, ErrorGroup) (at Assets/Xsolla/Core/WebRequests/WebRequestHelper.POST.cs:34)
Xsolla.Auth.XsollaAuth:SignIn(String, String, Action, Action`1, String) (at Assets/Xsolla/Auth/XsollaAuth.cs:110)
```
In this example stack trace was caused by the classic auth, but anything using `Xsolla.Core.WebRequestHelper.GetUnityParameters` has the same issue.

## Cause
Xsolla Analytics is providing uppercase headers using OS Locale, turning `X-BUILD-PLATFORM` header's `StandaloneWindows64` into `STANDALONEWİNDOWS64` when display language of the OS is Turkish. As this uppercase `İ` is not a valid English character, the above exception was thrown.

## Resolution
Turning upper and lower options into Invariant Culture fixed the issue.